### PR TITLE
Simplify CircleCI build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,3 @@
-## Customize the test machine
 general:
   branches:
     only:
@@ -6,23 +5,13 @@ general:
       - CircleCI
 
 machine:
-#  timezone:
-#    Pacific/Auckland # Currently only affects mysql, which isn't used
   java:
     version: openjdk8
 
-## Customize dependencies
 dependencies:
-  # pre:
-    # - curl -s "https://get.sdkman.io" | bash # I want SDKMAN!
-    # - mkdir -p ~/.sdkman/etc
-    # - echo sdkman_auto_answer=true > ~/.sdkman/etc/config
-    # - sdk install gradle
-    # - sdk install kotlin
   post:
     - ./gradlew assemble
 
-## Customize test commands
 test:
   post:
     - ./gradlew check

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,7 @@ general:
   branches:
     only:
       - master
+      - circleci
 
 machine:
 #  timezone:
@@ -11,20 +12,20 @@ machine:
     version: openjdk8
 
 ## Customize dependencies
-dependencies:
-  pre:
-    - curl -s "https://get.sdkman.io" | bash # I want SDKMAN!
-    - mkdir -p ~/.sdkman/etc
-    - echo sdkman_auto_answer=true > ~/.sdkman/etc/config
-    - sdk install gradle
-    - sdk install kotlin
-  post:
-    - ./gradlew assemble
+# dependencies:
+  # pre:
+    # - curl -s "https://get.sdkman.io" | bash # I want SDKMAN!
+    # - mkdir -p ~/.sdkman/etc
+    # - echo sdkman_auto_answer=true > ~/.sdkman/etc/config
+    # - sdk install gradle
+    # - sdk install kotlin
+  # post:
+    # - ./gradlew assemble
 
 ## Customize test commands
 test:
   post:
-    - ./gradlew check
+    # - ./gradlew check
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/
     - find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
 

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ general:
   branches:
     only:
       - master
-      - circleci
+      - CircleCI
 
 machine:
 #  timezone:
@@ -12,20 +12,20 @@ machine:
     version: openjdk8
 
 ## Customize dependencies
-# dependencies:
+dependencies:
   # pre:
     # - curl -s "https://get.sdkman.io" | bash # I want SDKMAN!
     # - mkdir -p ~/.sdkman/etc
     # - echo sdkman_auto_answer=true > ~/.sdkman/etc/config
     # - sdk install gradle
     # - sdk install kotlin
-  # post:
-    # - ./gradlew assemble
+  post:
+    - ./gradlew assemble
 
 ## Customize test commands
 test:
   post:
-    # - ./gradlew check
+    - ./gradlew check
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/
     - find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
 


### PR DESCRIPTION
Achieves the same result as before, using gradlew only.
Avoids the need to install sdkman and Kotlin manually.